### PR TITLE
Fix for 2 vulnerable dependency paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "moment": "~2.8.4",
     "nedb": "~0.11.1",
     "node-uuid": "~1.4.1",
-    "request": "~2.40.0",
+    "request": "~2.74.0",
     "request-progress": "~0.3.1",
     "retry": "~0.6.0",
     "seek-bzip": "~1.0.3",


### PR DESCRIPTION
d2rm currently has a 5 vulnerable dependency paths, introducing 5 different types of known vulnerabilities.

This PR fixes vulnerable dependencies.
- [ReDOS vulnerability](https://snyk.io/vuln/npm:hawk:20160119) in the `hawk` dependency.
- [remote memory exposure ](https://snyk.io/vuln/npm:request:20160119) vulnerability in the `request` dependency.

You can see [Snyk test report](https://snyk.io/test/github/d2rm/d2rm) of this project for details. 

This PR changes `Package.json` to upgrade `request` to the newer 2.74.0 version, and will fix the vulnerability listed above.

You can get alerts and fix PRs for future vulnerabilities for free by [watching this repo with Snyk](https://snyk.io/add).

Note this PR fixes all the vulnerabilities introduced trough `request` dependency, in order to be vulnerability free you will need to upgrade others dependencies as well.

Stay Secure,
The Snyk Team
